### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
-
 # Model Context Protocol ( MCP ) Python server to use with continue.dev
 MCP server that exposes a customizable prompt templates, resources, and tools
 It uses FastMCP to run as server application.
 
 Dependencies, build, and run managed by uv tool.
+
+<a href="https://glama.ai/mcp/servers/@alexsmirnov/mcp-server-continue">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@alexsmirnov/mcp-server-continue/badge" alt="Server for continue.dev MCP server" />
+</a>
 
 ## Provided functionality
 ### prompts


### PR DESCRIPTION
This PR adds a badge for the [MCP Server for continue.dev](https://glama.ai/mcp/servers/@alexsmirnov/mcp-server-continue) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@alexsmirnov/mcp-server-continue">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@alexsmirnov/mcp-server-continue/badge" alt="Server for continue.dev MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.